### PR TITLE
feat(string): Add support for extracting code blocks without end markers

### DIFF
--- a/pyassorted/string/find.py
+++ b/pyassorted/string/find.py
@@ -31,7 +31,9 @@ def find_placeholders(
     return re.findall(pattern, text)
 
 
-def extract_code_blocks(text: Text, language: Text) -> List[Text]:
+def extract_code_blocks(
+    text: Text, language: Text, eob_missing_ok: bool = False
+) -> List[Text]:
     """Extract code blocks for specified languages from a text.
 
     Parameters
@@ -52,6 +54,16 @@ def extract_code_blocks(text: Text, language: Text) -> List[Text]:
     ['{"key": "value"}']
     """
 
-    # Pattern to find blocks that start with ```<language>\n and end with ```
-    pattern = rf"```{language.strip()}\n(.*?)(?=```)"
-    return re.findall(pattern, text, flags=re.DOTALL)
+    if eob_missing_ok is True:
+        bob = f"```{language.strip()}\n"
+        eob = "\n```"
+        _text_parts = text.split(bob)
+        if len(_text_parts) == 1:
+            return []
+        return [_text_parts[-1].split(eob)[0]]
+
+    else:
+        # Pattern to find blocks that start with ```<language>\n and end with ```
+        pattern = rf"```{language.strip()}\n(.*?)(?=```)"
+        # pattern = rf"```.*?\n(.*?)(?=```)"
+        return re.findall(pattern, text, flags=re.DOTALL)

--- a/tests/string/test_string.py
+++ b/tests/string/test_string.py
@@ -164,10 +164,16 @@ def test_limit_consecutive_newlines(text, max_newlines, expected_output):
             ["package main\nfunc main() {}"],
         ),
         ("No end marker ```go\npackage main\nfunc main() {}", "go", []),
+        (
+            "No end marker (eob_missing_ok=true) ```go\npackage main\nfunc main() {}",
+            "go",
+            ["package main\nfunc main() {}"],
+        ),
     ],
 )
 def test_extract_code_blocks(text, language, expected_output):
-    result = extract_code_blocks(text, language)
+    eob_missing_ok = True if "eob_missing_ok=true" in text.casefold() else False
+    result = extract_code_blocks(text, language, eob_missing_ok=eob_missing_ok)
     assert (
         result == expected_output
     ), f"Expected '{expected_output}', but got '{result}'"


### PR DESCRIPTION
- Add `eob_missing_ok` parameter to `extract_code_blocks` function
- Implement logic to handle missing end-of-block markers when `eob_missing_ok` is True
- Update test case to cover new functionality